### PR TITLE
Libraries

### DIFF
--- a/code/simple-webcam/src/main/java/com/nbicocchi/javafx/camera/common/AlertWindows.java
+++ b/code/simple-webcam/src/main/java/com/nbicocchi/javafx/camera/common/AlertWindows.java
@@ -2,8 +2,8 @@ package com.nbicocchi.javafx.camera.common;
 
 import javafx.scene.control.Alert;
 
-public class AlertWindows {
-    public static void showFailedToTakePictureAlert() {
+public interface AlertWindows {
+    static void showFailedToTakePictureAlert() {
         Alert alert = new Alert(Alert.AlertType.WARNING);
         alert.getDialogPane().setMinWidth(675);
         alert.getDialogPane().setMaxWidth(675);
@@ -19,7 +19,7 @@ public class AlertWindows {
         alert.showAndWait();
     }
 
-    public static void showFatalError() {
+    static void showFatalError() {
         Alert alert = new Alert(Alert.AlertType.ERROR);
         alert.getDialogPane().setMinWidth(400);
         alert.getDialogPane().setMaxWidth(300);
@@ -31,7 +31,7 @@ public class AlertWindows {
         alert.showAndWait();
     }
 
-    public static void showDialogAlert(String headerText, String contentText) {
+    static void showDialogAlert(String headerText, String contentText) {
         Alert alert = new Alert(Alert.AlertType.ERROR);
         alert.getDialogPane().setMinWidth(400);
         alert.getDialogPane().setMaxWidth(300);

--- a/code/simple-webcam/src/main/java/com/nbicocchi/javafx/camera/common/WebcamUtils.java
+++ b/code/simple-webcam/src/main/java/com/nbicocchi/javafx/camera/common/WebcamUtils.java
@@ -7,8 +7,8 @@ import com.github.sarxos.webcam.Webcam;
 import com.github.sarxos.webcam.WebcamResolution;
 import javafx.collections.ObservableList;
 
-public class WebcamUtils {
-    private static final Dimension[] nonStandardResolutions = new Dimension[] {
+public interface WebcamUtils {
+     Dimension[] NON_STANDARD_RESOLUTIONS = new Dimension[] {
             WebcamResolution.QQVGA.getSize(),
             WebcamResolution.HQVGA.getSize(),
             WebcamResolution.QVGA.getSize(),
@@ -36,11 +36,11 @@ public class WebcamUtils {
             WebcamResolution.QHD.getSize(),
             WebcamResolution.UHD4K.getSize()
     };
-    private static final Dimension defaultResolution = nonStandardResolutions[0];
+    Dimension DEFAULT_RESOLUTION = NON_STANDARD_RESOLUTIONS[0];
 
     private static boolean isValidResolution(Dimension resolution) {
         Objects.requireNonNull(resolution);
-        for (Dimension dimension : nonStandardResolutions) {
+        for (Dimension dimension : NON_STANDARD_RESOLUTIONS) {
             if (resolution.equals(dimension)) {
                 return true;
             }
@@ -48,18 +48,18 @@ public class WebcamUtils {
         return false;
     }
 
-    public static void startUpWebcam(Webcam webcam, Dimension resolution) {
+    static void startUpWebcam(Webcam webcam, Dimension resolution) {
         Objects.requireNonNull(webcam);
         if (webcam.isOpen()) {
             throw new RuntimeException("Webcam has been already initialized.");
         }
         webcam.open();
-        webcam.setCustomViewSizes(nonStandardResolutions);
+        webcam.setCustomViewSizes(NON_STANDARD_RESOLUTIONS);
         Dimension[] dimensionsSupported = webcam.getDevice().getResolutions();
         Dimension maxDimension = dimensionsSupported[dimensionsSupported.length - 1];
         if (Objects.isNull(resolution)) {
             if (Objects.isNull(maxDimension)) {
-                resolution = defaultResolution;
+                resolution = DEFAULT_RESOLUTION;
             } else {
                 resolution = maxDimension;
             }
@@ -70,7 +70,7 @@ public class WebcamUtils {
         }
     }
 
-    public static void changeResolution(Webcam webcam, Dimension resolution) {
+    static void changeResolution(Webcam webcam, Dimension resolution) {
         Objects.requireNonNull(webcam);
         Objects.requireNonNull(resolution);
         if (!isValidResolution(resolution)) {
@@ -82,7 +82,7 @@ public class WebcamUtils {
         webcam.open();
     }
 
-    public static void shutDownWebcams(ObservableList<Webcam> webcams) {
+    static void shutDownWebcams(ObservableList<Webcam> webcams) {
         for (Webcam webcam: webcams) {
             if (webcam.isOpen()) {
                 webcam.close();


### PR DESCRIPTION
Since WebcamUtils and AlertWindows were classes composed only by static methods, they had no constructor and no modifiable variables, I think it is better to turn them into interface. They are utility's libraries. 

**Important**: if you accept pr2, these two interface should be moved to the _lib_ package